### PR TITLE
add @notice and refactoring

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -7,7 +7,7 @@ Deployment scirpts for [ISUCON9](http://isucon.net/archives/53231706.html).
 
 ## Setup
 ```
-$ pip install 'fabric<2' cuisine
+$ pip install 'fabric<2' cuisine requests
 ```
 
 ## Initial Deploy

--- a/infra/fabfile/__init__.py
+++ b/infra/fabfile/__init__.py
@@ -1,0 +1,1 @@
+import init

--- a/infra/fabfile/init.py
+++ b/infra/fabfile/init.py
@@ -1,15 +1,21 @@
 # -*- coding: utf-8*
 from fabric.api import *
+from notification import notice
 import cuisine
 import urllib
 
-USERS = ['yuta1024', 'tyabuki', 'nhirokinet']
 
-cuisine.select_package('apt')
-cuisine.select_hash('openssl')
-
-@task
+@task(default=True)
+@runs_once
+@notice
 def init():
+    execute(_init)
+
+
+def _init():
+    cuisine.select_package('apt')
+    cuisine.select_hash('openssl')
+
     _setup_users()
     _setup_repositories()
     _setup_kataribe()
@@ -65,7 +71,7 @@ def _setup_percona_repository():
 
 
 def _setup_users():
-    for user in USERS:
+    for user in ['yuta1024', 'tyabuki', 'nhirokinet']:
         cuisine.user_ensure(user, shell='/bin/bash', passwd='yharima', encrypted_passwd=False)
         cuisine.group_user_ensure('sudo', user)
         with cuisine.mode_sudo():

--- a/infra/fabfile/notification.py
+++ b/infra/fabfile/notification.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8*
+from fabric.api import *
+import functools
+import requests
+import subprocess
+
+# TODO: Revoke it after contests is ended
+WEBHOOK_URL = 'https://discordapp.com/api/webhooks/618078607947989003/xT9A2caxLEuhFJHTNShloF-7ch6WXrwhBnqkGyLqFCHZFUbzkO2l560cXNBZFWBb4bKB'
+
+
+def notice(func, here=False):
+    @functools.wraps(func)
+    def decorated(*args, **kwargs):
+        func(*args, **kwargs)
+        notify()
+    return decorated
+
+
+def notify():
+    msg = [
+        '`%s` executed `%s` the following servers(%s).' % (env.user, ', '.join(env.tasks), get_commit_hash()),
+        '```',
+        '\n'.join(map(lambda h: '- %s' % h, env.hosts)),
+        '```'
+    ]
+
+    requests.post(
+        WEBHOOK_URL,
+        {
+            'content': '\n'.join(msg)
+        }
+    )
+
+
+def get_commit_hash():
+    hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).strip()
+
+    if subprocess.check_output(['git', 'status', '--porcelain']).strip() != '':
+        return '`%s` + local changes' % hash
+    return '`%s`' % hash


### PR DESCRIPTION
fabfile の分割とタスク実行後に Discord へ通知できる `@notice` を追加しました．
通知内容は以下です．
- SSH 実行ユーザ
- 実行 fabric task
- コミットハッシュ
- ローカルの変更を含んでいるか
- 実行サーバリスト

サンプル
<img width="910" alt="スクリーンショット 2019-09-04 0 24 07" src="https://user-images.githubusercontent.com/904622/64186754-5528a500-ceaa-11e9-9f27-c2b500826678.png">
