### PR TITLE
use percona-server-8

### DIFF
--- a/infra/fabfile/init.py
+++ b/infra/fabfile/init.py
@@ -68,6 +68,7 @@ def _setup_percona_repository():
         run('wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb')
         sudo('dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb')
         run('rm percona-release_latest.$(lsb_release -sc)_all.deb')
+        sudo('percona-release setup ps80')
 
 
 def _setup_users():

--- a/infra/fabfile/setup.py
+++ b/infra/fabfile/setup.py
@@ -28,8 +28,10 @@ def install_percona_server():
 def _install_percona_server():
     cuisine.select_package('apt')
     # https://jfg-mysql.blogspot.com/2018/11/howto-install-percona-server-57-on-debian-without-root-password-prompt.html
-    sudo('debconf-set-selections <<< "percona-server-server-5.7 percona-server-server-5.7/root-pass password Knishiya248!"')
-    sudo('debconf-set-selections <<< "percona-server-server-5.7 percona-server-server-5.7/re-root-pass password Knishiya248!"')
-    sudo('apt install -y percona-server-server-5.7 percona-toolkit')
+    sudo('debconf-set-selections <<< "percona-server-server percona-server-server/root-pass password Knishiya248!"')
+    sudo('debconf-set-selections <<< "percona-server-server percona-server-server/re-root-pass password Knishiya248!"')
+    # https://geert.vanderkelen.org/2018/mysql8-unattended-dpkg/
+    sudo('debconf-set-selections <<< "percona-server-server percona-server-server/default-auth-override select Use Legacy Authentication Method (Retain MySQL 5.x Compatibility)"')
+    sudo('apt install -y percona-server-server percona-toolkit')
     sudo('systemctl enable mysql')
     sudo('systemctl start mysql')

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -13,8 +13,11 @@ services:
       # - .:/opt/isucon/webapp/php
       # - ./static:/opt/isucon/webapp/static
   db:
-    image: percona:5.7
+    image: percona:8
     container_name: db
+    # Workaround: PHP don't support authentication method caching_sha2_password
+    # https://github.com/docker-library/mysql/issues/454
+    command: --default-authentication-plugin=mysql_native_password
     volumes:
       - ./docker/mysql-data:/var/lib/mysql
       # - ./db/isucon.sql:/docker-entrypoint-initdb.d/00-isucon.sql


### PR DESCRIPTION
percona-server-8 にしました．
https://www.percona.com/doc/percona-server/8.0/installation/apt_repo.html

PHP が残念で新しい authentication method に対応していないらしいので docker 側も含めて古いものにしています．

ISUCON8 のベンチはパスしました．