### PR TITLE
fix repo for ps8

### DIFF
--- a/infra/fabfile/init.py
+++ b/infra/fabfile/init.py
@@ -64,7 +64,7 @@ def _setup_percona_repository():
     # https://www.percona.com/doc/percona-server/5.7/installation/apt_repo.html
     cuisine.package_ensure('wget')
 
-    if not cuisine.file_exists('/etc/apt/sources.list.d/percona-original-release.list'):
+    if not cuisine.file_exists('/etc/apt/sources.list.d/percona-ps-80-release.list'):
         run('wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb')
         sudo('dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb')
         run('rm percona-release_latest.$(lsb_release -sc)_all.deb')


### PR DESCRIPTION
`sudo percona-release setup ps80` すると `/etc/apt/sources.list.d/` が以下のようになるのでそちらに対応しました．
```
$ ls -l /etc/apt/sources.list.d/
total 32
-rw-r--r-- 1 root root  59 Sep  5 15:54 nginx.list
-rw-r--r-- 1 root root  59 Sep  5 15:54 nginx.list.save
-rw-r--r-- 1 root root 124 Sep  5 15:54 ondrej-ubuntu-php-bionic.list
-rw-r--r-- 1 root root 178 Sep  6 06:46 percona-original-release.list.bak
-rw-r--r-- 1 root root 174 Sep  6 06:52 percona-ps-80-release.list
-rw-r--r-- 1 root root 174 Sep  6 06:46 percona-ps-80-release.list.bak
-rw-r--r-- 1 root root 174 Sep  6 06:52 percona-tools-release.list
-rw-r--r-- 1 root root 174 Sep  6 06:46 percona-tools-release.list.bak
```