### PR TITLE
add log task and kataribe.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 *.pyc
 src/docker/mysql-data/
+infra/merged.log

--- a/infra/README.md
+++ b/infra/README.md
@@ -41,3 +41,9 @@ Deploys files and config files of a web application and restart `nginx` and `php
 
 ### deploy.deploy_db
 Deploys config files of a database and restart `mysql`.
+
+### log.logrotate
+Compresses logs and create new empty log files.
+
+### log.kataribe
+Collects access logs and analyzes them using kataribe.

--- a/infra/fabfile/__init__.py
+++ b/infra/fabfile/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8*
 import deploy
 import init
+import log
 import setup

--- a/infra/fabfile/log.py
+++ b/infra/fabfile/log.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8*
+from fabric.api import *
+from notification import notice
+import cuisine
+
+
+@task
+@runs_once
+@notice
+def logrotate():
+    execute(_logrotate)
+
+
+def _logrotate():
+    date = run('date "+%y%m%d-%H%M%S"')
+    if cuisine.file_exists('/var/log/nginx/access.log'):
+        sudo('gzip -c /var/log/nginx/access.log > /var/log/nginx/access-%s.gz' % date)
+        sudo(': > /var/log/nginx/access.log')
+    if cuisine.file_exists('/var/log/nginx/error.log'):
+        sudo('gzip -c /var/log/nginx/access.log > /var/log/nginx/error-%s.gz' % date)
+        sudo(': > /var/log/nginx/error.log')
+
+
+@task
+@runs_once
+def kataribe():
+    execute(_kataribe)
+    local('cat %s > merged.log' % ' '.join(env.hosts))
+    local('rm %s' % ' '.join(env.hosts))
+    local('cat merged.log | kataribe')
+
+
+def _kataribe():
+    if cuisine.file_exists('/var/log/nginx/access.log'):
+        get('/var/log/nginx/access.log', env.host)

--- a/infra/kataribe.toml
+++ b/infra/kataribe.toml
@@ -1,0 +1,81 @@
+# Top Ranking Group By Request
+ranking_count = 20
+
+# Top Slow Requests
+slow_count = 37
+
+# Show Standard Deviation column
+show_stddev = true
+
+# Show HTTP Status Code columns
+show_status_code = true
+
+# Show HTTP Response Bytes columns
+show_bytes = true
+
+# Percentiles
+percentiles = [ 50.0, 90.0, 95.0, 99.0 ]
+
+# for Nginx($request_time)
+scale = 0
+effective_digit = 3
+
+# for Apache(%D) and Varnishncsa(%D)
+#scale = -6
+#effective_digit = 6
+
+# for Rack(Rack::CommonLogger)
+#scale = 0
+#effective_digit = 4
+
+
+# combined + duration
+# Nginx example: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_time'
+# Apache example: "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %D"
+# H2O example: "%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\" %{duration}x"
+# Varnishncsa example: '%h %l %u %t "%r" %s %b "%{Referer}i" "%{User-agent}i" %D'
+log_format = '^([^ ]+) ([^ ]+) ([^ ]+) \[([^\]]+)\] "((?:\\"|[^"])*)" (\d+) (\d+|-) "((?:\\"|[^"])*)" "((?:\\"|[^"])*)" ([0-9.]+)$'
+
+request_index = 5
+status_index = 6
+bytes_index = 7
+duration_index = 10
+
+# Rack example: use Rack::CommonLogger, Logger.new("/tmp/app.log")
+#log_format = '^([^ ]+) ([^ ]+) ([^ ]+) \[([^\]]+)\] "((?:\\"|[^"])*)" (\d+) (\d+|-) ([0-9.]+)$'
+#request_index = 5
+#status_index = 6
+#bytes_index = 7
+#duration_index = 8
+
+# You can aggregate requests by regular expression
+# For overview of regexp syntax: https://golang.org/pkg/regexp/syntax/
+[[bundle]]
+regexp = '^(GET|HEAD) /memo/[0-9]+\b'
+name = "get memo"
+
+[[bundle]]
+regexp = '^(GET|HEAD) /stylesheets/'
+name = "stylesheets"
+
+[[bundle]]
+regexp = '^(GET|HEAD) /images/'
+name = "images"
+
+# You can replace the part of urls which matched to your regular expressions.
+# For overview of regexp syntax: https://golang.org/pkg/regexp/syntax/
+#[[replace]]
+#regexp = '/[0-9]+/'
+#replace = '/<num>/'
+#
+#[[replace]]
+#regexp = '/[0-9]+\s'
+#replace = '/<num> '
+#
+#[[replace]]
+#regexp = '=[0-9]+&'
+#replace = '=<num>&'
+#
+#[[replace]]
+#regexp = '=[0-9]+\s'
+#replace = '=<num> '


### PR DESCRIPTION
ログをローテートするタスク（今は nginx だけで config 揃ってきたら他もサポートする）と
アクセスログを収集してローカルで kataribe を実行するタスクを生やしました．

各自 fabric を実行するマシンで kataribe を入れてください．
https://github.com/matsuu/kataribe