### PR TITLE
update to kataribe v0.4.1

### DIFF
--- a/infra/fabfile/init.py
+++ b/infra/fabfile/init.py
@@ -26,11 +26,11 @@ def _setup_kataribe():
     cuisine.package_ensure('unzip')
 
     if not cuisine.file_exists('/usr/local/bin/kataribe'):
-        run('wget https://github.com/matsuu/kataribe/releases/download/v0.3.3/linux_amd64.zip')
-        run('echo "9c4a4fe72651e33b1a6ef55f5e672fa38b755d48 linux_amd64.zip" | sha1sum -c -')
-        run('unzip linux_amd64.zip kataribe')
+        run('wget https://github.com/matsuu/kataribe/releases/download/v0.4.1/kataribe-v0.4.1_linux_amd64.zip')
+        run('echo "34da63eb1696b964d30d9fac3b6c2778b9797eb4 kataribe-v0.4.1_linux_amd64.zip" | sha1sum -c -')
+        run('unzip kataribe-v0.4.1_linux_amd64.zip kataribe')
         sudo('mv ./kataribe /usr/local/bin')
-        run('rm linux_amd64.zip')
+        run('rm kataribe-v0.4.1_linux_amd64.zip')
 
 
 def _setup_repositories():


### PR DESCRIPTION
kataribe が更新されているので最新へ
https://github.com/matsuu/kataribe/releases/tag/v0.4.1